### PR TITLE
Fix get_valid_filename() for Gitlab usage.

### DIFF
--- a/mdsplit.py
+++ b/mdsplit.py
@@ -274,8 +274,8 @@ def get_valid_filename(name):
     """
     Adapted from https://github.com/django/django/blob/main/django/utils/text.py
     """
-    s = str(name).strip()
-    s = re.sub(r"(?u)[^-\w. ]", "", s)
+    s = str(name).strip().replace(" ", "-")
+    s = re.sub(r"(?u)[^-\w.]", "", s)
     if s in {"", ".", ".."}:
         raise ValueError(f"Could not derive file name from '{name}'")
     return s


### PR DESCRIPTION
Filenames with spaces are not working with Gitlab Wiki. Spaces are substituded by hyphen.

See also #7 